### PR TITLE
Experiments: Coin Counter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ deobfuscated
 *.dll
 bin/
 build/
+.vscode/settings.json

--- a/Makefile
+++ b/Makefile
@@ -20,22 +20,22 @@ OBJS = minifb.o nes_apu.o nes_dmc.o common.o smbstuff.o
 all: in_nes.dll
 
 in_nes.dll: src/plugin.c $(OBJS)
-	i686-w64-mingw32-c++ -g3 -Os $(CFLAGS) -o $@ $^ $(LDFLAGS) -static
+	i686-w64-mingw32-c++ -g3 -Og $(CFLAGS) -o $@ $^ $(LDFLAGS) -static
 
 smbstuff.o: src/smbstuff.cpp
-	i686-w64-mingw32-c++ -g3 -Os $(CFLAGS) -c -o $@ $< -static
+	i686-w64-mingw32-c++ -g3 -Og $(CFLAGS) -c -o $@ $< -static
 
 minifb.o: src/WinMiniFB.c
-	i686-w64-mingw32-c++ -g3 -Os $(CFLAGS) -c -o $@ $< -static
+	i686-w64-mingw32-c++ -g3 -Og $(CFLAGS) -c -o $@ $< -static
 
 nes_apu.o: nes_nsfplay/nes_apu.cpp
-	i686-w64-mingw32-c++ -g3 -Os $(CFLAGS) -c -o $@ $< -static
+	i686-w64-mingw32-c++ -g3 -Og $(CFLAGS) -c -o $@ $< -static
 
 nes_dmc.o: nes_nsfplay/nes_dmc.cpp
-	i686-w64-mingw32-c++ -g3 -Os $(CFLAGS) -c -o $@ $< -static
+	i686-w64-mingw32-c++ -g3 -Og $(CFLAGS) -c -o $@ $< -static
 
 common.o: nes_nsfplay/common.cpp
-	i686-w64-mingw32-c++ -g3 -Os $(CFLAGS) -c -o $@ $< -static
+	i686-w64-mingw32-c++ -g3 -Og $(CFLAGS) -c -o $@ $< -static
 
 clean:
 	rm -f in_nes.dll $(OBJS)

--- a/makencopy
+++ b/makencopy
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+make clean ; make
+cp in_nes.dll '/home/dinnerbird/.wine/drive_c/Program Files (x86)/WACUP/Plugins'
+
+

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -38,12 +38,16 @@ void eq_set(int on, char data[10], int preamp);
 void wa_main(int argc, char **argv);
 void run_emulator_cycles(unsigned int target_cycles);
 
+void updateCoinKHz();
+
 bool newrom = false;
 
 int bitrate = 0;
 int srate = 0;
 int stereo = 0;
 int synced = 0;
+
+int cash_money = 0;
 
 In_Module mod =		// the output module
 {
@@ -138,6 +142,7 @@ uint8_t *rom, *chrrom,                // Points to the start of PRG/CHR ROM
     last_world,
     last_level;
 
+
 uint16_t scany,          // Scanline Y
     T, V,                // "Loopy" PPU registers
     sum,                 // Sum used for ADC/SBC
@@ -224,6 +229,7 @@ int play(const char* fn) {
   OutputDebugString(str);
 
   mod.SetInfo(bitrate, srate, stereo, synced);
+  
   //mod.SAVSAInit(maxlatency, 44100);
   // where we're going, we don't need maxlatency
   // you cant see into the future in an NES emulator anyway
@@ -479,15 +485,20 @@ uint8_t mem(uint8_t lo, uint8_t hi, uint8_t val, uint8_t write) {
     // $4016 Joypad 1
     for (tmp = 0, hi = 8; hi--;)
     // losely based on niftsky's input mapping for his speedruns
+    /* however in my branch I'd prefer something SANER
+    Eris reworked these to use Win32 VK codes instead
+    And when you're done reading this sentence, M$ has already broken the documentation links and shuffled everything around 20 times
+    */
+
       tmp = tmp * 2 + key_state[(uint8_t[]){
-                          0x60,      // A
-                          0x27,      // B
-                          'G',    // Select
-                          'J', // Start
-                          'W',     // Dpad Up
-                          'S',   // Dpad Down
-                          'A',   // Dpad Left
-                          'D',  // Dpad Right
+                          'X',      // A
+                          'Z',      // B
+                          0xDC,    // Select
+                          0x0D, // Start
+                          0x26,     // Dpad Up
+                          0x28,   // Dpad Down
+                          0x25,   // Dpad Left
+                          0x27,  // Dpad Right
                       }[hi]];
     if (lo == 22) {
       if (write) {
@@ -1092,6 +1103,11 @@ void run_emulator_cycles(unsigned int target_cycles)
   } // while(consumed < target_cycles)
 } // run_emulator_cycles
 
+void updateCoinKHz()
+{
+  mod.SetInfo(cash_money, srate, stereo, synced);
+}
+
 void stop() {
   done = 1;
   WaitForSingleObject(hThread, 500);
@@ -1139,6 +1155,8 @@ void setpan(int pan)
 {
   mod.outMod->SetPan(pan);
 }
+
+
 
 void getfileinfo(const char* filename, char* title, int* length_in_ms)
 {

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -2,14 +2,14 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include <stdlib.h>
-
+#include "plugin.h"
 #define WIN32_LEAN_AND_MEAN
-#include "../nes_nsfplay/common.h"
+#include "../nes_nsfplay/common.h" // Seems to piss off vscode for some reason, doesn't work without
 #include "MiniFB.h"
 #include "../thirdparty/wacup/in2.h" // wacup input plugin api
 #include "../thirdparty/wacup/wa_ipc.h" // wacup ipc api
 #include "../nes_nsfplay/xtypes.h"
-#include "plugin.h"
+
 
 #define PLUGIN_VERSION "1.0.0"
 char lastfn[MAX_PATH];
@@ -47,7 +47,7 @@ int srate = 0;
 int stereo = 0;
 int synced = 0;
 
-int cash_money = 0;
+uint8_t cash_money;
 
 In_Module mod =		// the output module
 {
@@ -398,7 +398,11 @@ uint8_t mem(uint8_t lo, uint8_t hi, uint8_t val, uint8_t write) {
   // any other game produces unexpected results
   SuperMarioBrosSpecificHacks(addr, val, write);
 
-  mod.SetInfo(bitrate, srate, stereo, dead);
+  // oh well
+
+
+// really hacky
+  mod.SetInfo(cash_money, srate, stereo, dead);
 
   xgm::nes1_NP->Write(addr,val);
   xgm::nes2_NP->Write(addr,val);
@@ -1102,11 +1106,6 @@ void run_emulator_cycles(unsigned int target_cycles)
     consumed += cycles;
   } // while(consumed < target_cycles)
 } // run_emulator_cycles
-
-void updateCoinKHz()
-{
-  mod.SetInfo(cash_money, srate, stereo, synced);
-}
 
 void stop() {
   done = 1;

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -14,4 +14,6 @@ extern bool length_determiner;
 
 extern void SuperMarioBrosSpecificHacks(uint16_t addr, uint8_t val, uint8_t write);
 
+extern int cash_money;
+
 #endif

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -14,6 +14,6 @@ extern bool length_determiner;
 
 extern void SuperMarioBrosSpecificHacks(uint16_t addr, uint8_t val, uint8_t write);
 
-extern int cash_money;
+extern uint8_t cash_money;
 
 #endif

--- a/src/smbstuff.cpp
+++ b/src/smbstuff.cpp
@@ -93,7 +93,6 @@ void SuperMarioBrosSpecificHacks(uint16_t addr, uint8_t val, uint8_t write) {
     // This is a hex value instead of BCD fuckery
 
     if (addr == 0x075E && write) { // detect writes on $075E
-        uint8_t cash_money = 0;
       sprintf(str, "COIN at %04X val=%02X", addr, val); // tells me what address and what value is there
         char val_str[4];
         sprintf(val_str, "%02X", val);

--- a/src/smbstuff.cpp
+++ b/src/smbstuff.cpp
@@ -1,5 +1,14 @@
 #include "plugin.h"
+#include <cstdio>
+#include <debugapi.h>
+#include <cstdlib>
 
+/* 
+A bit of clarification if you're poking around here:
+addr    = CPU address
+val     = what memory value is it?
+write   = "hey, it's a write!"
+*/
 void SuperMarioBrosSpecificHacks(uint16_t addr, uint8_t val, uint8_t write) {
     char str[40];
     if (addr == 0x000E && val == 0x06){
@@ -74,4 +83,25 @@ void SuperMarioBrosSpecificHacks(uint16_t addr, uint8_t val, uint8_t write) {
             }
         }
     }
+    // Both in BCD (of course)
+    // $07ED and $07EE: Mario's coins
+    // $07F3 and $07F4: Luigi's coins
+
+    // BUT we can use $075E to get the onscreen player's coin count
+    // Goes up to $63 and then back to $00
+    // ($0765 is the "off-screen" player's coins)
+    // This is a hex value instead of BCD fuckery
+
+    if (addr == 0x075E && write) { // detect writes on $075E
+        uint8_t cash_money = 0;
+      sprintf(str, "COIN at %04X val=%02X", addr, val); // tells me what address and what value is there
+        char val_str[4];
+        sprintf(val_str, "%02X", val);
+        cash_money = strtol(val_str, nullptr, 16);
+        
+
+        OutputDebugString(str);
+        
+    }
+
 }

--- a/test
+++ b/test
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+winedbg --gdb '/home/dinnerbird/.wine/drive_c/Program Files (x86)/WACUP/wacup.exe' 
+


### PR DESCRIPTION
Added coin counter functionality to bit rate display. Currently only Super Mario Bros. works, but can also work as a "magic" numerical display if that game happens to use something else